### PR TITLE
CORE-583: publish messages over websocket

### DIFF
--- a/APIDOC.md
+++ b/APIDOC.md
@@ -19,7 +19,7 @@ Options for the data input can be provided in query parameters:
 
 Parameter | Required | Description
 --------- | -------- | -----------
-ttl       | no       | Time-To-Live, in seconds. The event will be deleted after this time has passed. If not given, the event storage period will be the stream default.
+ts        | no       | Time-To-Live, in seconds. The event will be deleted after this time has passed. If not given, the event storage period will be the stream default.
 pkey      | no       | For partitioned streams, provides the key to partition by. Can be eg. a customer id to make all events for that customer to go to the same Canvas for processing. If not given, a random partition is selected.
 
 

--- a/APIDOC.md
+++ b/APIDOC.md
@@ -19,7 +19,7 @@ Options for the data input can be provided in query parameters:
 
 Parameter | Required | Description
 --------- | -------- | -----------
-ts        | no       | Time-To-Live, in seconds. The event will be deleted after this time has passed. If not given, the event storage period will be the stream default.
+ts        | no       | Event timestamp in either ISO 8601 string format or milliseconds since epoch. If not given, time on server will be used. Note: if you provide a timestamp, always send events in chronological order.
 pkey      | no       | For partitioned streams, provides the key to partition by. Can be eg. a customer id to make all events for that customer to go to the same Canvas for processing. If not given, a random partition is selected.
 
 

--- a/PROTOCOL.md
+++ b/PROTOCOL.md
@@ -1,10 +1,23 @@
 # Protocol
 
-**PLEASE BE ADVISED: Below may be outdated!**
-
 ### Requests sent by client
 
 Also see the [Javascript client](https://github.com/streamr-dev/streamr-client) documentation.
+
+#### publish
+
+Publishes a new message to a stream. Requires a write permission to the stream.
+
+```
+{
+  "type": "publish",
+  "stream": "streamId",
+  "authKey": "authKey",
+  "msg": "{}",                 // the message as stringified json
+  "ts": 1533924184016,         // timestamp (optional), defaults to current time on server
+  "pkey": "deviceId"           // partition key (optional), defaults to none (random partition)
+}
+```
 
 #### subscribe
 

--- a/data-api.js
+++ b/data-api.js
@@ -11,6 +11,7 @@ const RedisOffsetFetcher = require('./src/RedisOffsetFetcher')
 const CassandraUtil = require('./src/CassandraUtil')
 const StreamrKafkaProducer = require('./src/KafkaUtil')
 const Partitioner = require('./src/Partitioner')
+const Publisher = require('./src/Publisher')
 
 // Check command line args
 optimist = optimist.usage(`You must pass the following command line options:
@@ -30,6 +31,7 @@ const redis = new RedisUtil(optimist.argv.redis.split(','), optimist.argv['redis
 const cassandra = new CassandraUtil(optimist.argv.cassandra.split(','), optimist.argv.keyspace)
 const redisOffsetFetcher = new RedisOffsetFetcher(optimist.argv.redis.split(',')[0], optimist.argv['redis-pwd'])
 const kafka = new StreamrKafkaProducer(optimist.argv['data-topic'], Partitioner, optimist.argv.zookeeper)
+const publisher = new Publisher(kafka, Partitioner)
 
 // Create HTTP server
 const app = express()
@@ -52,7 +54,7 @@ const server = new WebsocketServer(
 
 // Rest endpoints
 app.use('/api/v1', require('./src/rest/DataQueryEndpoints')(cassandra, streamFetcher))
-app.use('/api/v1', require('./src/rest/DataProduceEndpoints')(streamFetcher, kafka, Partitioner))
+app.use('/api/v1', require('./src/rest/DataProduceEndpoints')(streamFetcher, publisher))
 
 // Start the server
 httpServer.listen(optimist.argv.port, () => {

--- a/data-api.js
+++ b/data-api.js
@@ -50,6 +50,7 @@ const server = new WebsocketServer(
     cassandra,
     redisOffsetFetcher,
     streamFetcher,
+    publisher,
 )
 
 // Rest endpoints

--- a/src/Publisher.js
+++ b/src/Publisher.js
@@ -1,0 +1,38 @@
+const debug = require('debug')('Publisher')
+const StreamrBinaryMessage = require('./protocol/StreamrBinaryMessage')
+const InvalidMessageContentError = require('./errors/InvalidMessageContentError')
+const NotReadyError = require('./errors/NotReadyError')
+
+module.exports = class Publisher {
+    constructor(kafka, partitioner) {
+        this.kafka = kafka
+        this.partitioner = partitioner
+
+        kafka.on('ready', () => {
+            this.kafkaReady = true
+            debug('Kafka is ready')
+        })
+    }
+
+    async publish(stream, timestamp = Date.now(), ttl = 0, contentType, content, partitionKey) {
+        if (!content) {
+            throw new InvalidMessageContentError(`Empty message content rejected for stream ${stream.id}`)
+        }
+
+        // req.stream is written by authentication middleware
+        const streamPartition = this.partitioner.partition(stream.partitions, partitionKey)
+
+        if (!this.kafkaReady) {
+            throw new NotReadyError('Server not ready. Please try again shortly.')
+        }
+
+        return this.kafka.send(new StreamrBinaryMessage(
+            stream.id,
+            streamPartition,
+            timestamp || Date.now(),
+            ttl || 0,
+            contentType,
+            content,
+        ))
+    }
+}

--- a/src/WebsocketServer.js
+++ b/src/WebsocketServer.js
@@ -112,20 +112,20 @@ module.exports = class WebsocketServer extends events.EventEmitter {
         }
 
         this.streamFetcher.authenticate(req.stream, req.authKey, 'write')
-            .then((stream) => {
-                return this.publisher.publish(
-                    stream,
-                    timestamp,
-                    undefined, // ttl, read from stream when available
-                    StreamrBinaryMessage.CONTENT_TYPE_JSON,
-                    req.msg,
-                    req.pkey,
-                )
-            })
+            .then((stream) => this.publisher.publish(
+                stream,
+                timestamp,
+                undefined, // ttl, read from stream when available
+                StreamrBinaryMessage.CONTENT_TYPE_JSON,
+                req.msg,
+                req.pkey,
+            ))
             .catch((err) => {
                 let errorMsg
-                if (err instanceof HttpError && err.code === 403) {
-                    errorMsg = 'Authentication failed.'
+                if (err instanceof HttpError && err.code === 401) {
+                    errorMsg = `You are not allowed to write to stream ${req.stream}`
+                } else if (err instanceof HttpError && err.code === 403) {
+                    errorMsg = `Authentication failed while trying to publish to stream ${req.stream}`
                 } else if (err instanceof HttpError && err.code === 404) {
                     errorMsg = `Stream ${req.stream} not found.`
                 } else {

--- a/src/WebsocketServer.js
+++ b/src/WebsocketServer.js
@@ -101,8 +101,7 @@ module.exports = class WebsocketServer extends events.EventEmitter {
 
         this.streamFetcher.authenticate(req.stream, req.authKey, 'write')
             .then((stream) => {
-                console.log(stream)
-                this.publisher.publish(
+                return this.publisher.publish(
                     stream,
                     timestamp,
                     undefined, // ttl, read from stream when available

--- a/src/errors/FailedToPublishError.js
+++ b/src/errors/FailedToPublishError.js
@@ -1,0 +1,5 @@
+module.exports = class FailedToPublishError extends Error {
+    constructor(streamId, reason) {
+        super(`Publish to stream ${streamId} failed: ${reason}`)
+    }
+}

--- a/src/errors/InvalidMessageContentError.js
+++ b/src/errors/InvalidMessageContentError.js
@@ -1,0 +1,3 @@
+module.exports = class InvalidMessageContentError extends Error {
+
+}

--- a/src/errors/NotReadyError.js
+++ b/src/errors/NotReadyError.js
@@ -1,0 +1,3 @@
+module.exports = class NotReadyError extends Error {
+
+}

--- a/src/protocol/StreamrBinaryMessage.js
+++ b/src/protocol/StreamrBinaryMessage.js
@@ -5,6 +5,16 @@ const BufferReader = require('buffer-reader')
 const VERSION = 28 // 0x1C
 const CONTENT_TYPE_JSON = 27 // 0x1B
 
+function ensureBuffer(content) {
+    if (Buffer.isBuffer(content)) {
+        return content
+    } else if (typeof content === 'string') {
+        return Buffer.from(content, 'utf8')
+    }
+
+    throw new Error(`Unable to convert content to a Buffer! Type is: ${typeof content}`)
+}
+
 class StreamrBinaryMessage {
     constructor(streamId, streamPartition, timestamp, ttl, contentType, content) {
         this.version = VERSION
@@ -13,11 +23,7 @@ class StreamrBinaryMessage {
         this.timestamp = (timestamp instanceof Date ? timestamp.getTime() : timestamp)
         this.ttl = ttl
         this.contentType = contentType
-
-        if (!Buffer.isBuffer(content)) {
-            throw new Error('content is not a Buffer!')
-        }
-        this.content = content
+        this.content = ensureBuffer(content)
     }
 
     toBytes() {
@@ -29,7 +35,7 @@ class StreamrBinaryMessage {
 
     toBufferMaker(bufferMaker) {
         const streamIdBuf = new BufferMaker().string(this.streamId).make()
-        const contentBuf = Buffer.isBuffer(this.content) ? this.content : new BufferMaker().string(JSON.stringify(this.content)).make()
+        const contentBuf = ensureBuffer(this.content)
 
         return bufferMaker
         // byte 0: version (1 byte)

--- a/src/utils/TimestampUtil.js
+++ b/src/utils/TimestampUtil.js
@@ -1,0 +1,17 @@
+module.exports = {
+    parse: (millisOrString) => {
+        if (typeof millisOrString === 'number') {
+            return millisOrString
+        } else if (typeof millisOrString === 'string') {
+            // Try if this string represents a number
+            const timestamp = Number(millisOrString) || Date.parse(millisOrString)
+            if (Number.isNaN(timestamp)) {
+                throw new Error(`Invalid timestamp: ${millisOrString}`)
+            } else {
+                return timestamp
+            }
+        } else {
+            throw new Error(`Invalid timestamp: ${millisOrString}`)
+        }
+    },
+}

--- a/src/utils/VolumeLogger.js
+++ b/src/utils/VolumeLogger.js
@@ -1,0 +1,29 @@
+module.exports = class VolumeLogger {
+    constructor(reportingIntervalSeconds = 60) {
+        this.reportingIntervalSeconds = reportingIntervalSeconds
+        this.connectionCount = 0
+        this.inCount = 0
+        this.outCount = 0
+
+        if (this.reportingIntervalSeconds > 0) {
+            setInterval(() => {
+                this.log()
+            }, this.reportingIntervalSeconds * 1000)
+        }
+    }
+
+    log() {
+        const inPerSecond = this.inCount / this.reportingIntervalSeconds
+        const outPerSecond = this.outCount / this.reportingIntervalSeconds
+
+        console.log(
+            'Connections: %d, Messages in/sec: %d, Messages out/sec: %d',
+            this.connectionCount,
+            inPerSecond < 10 ? inPerSecond.toFixed(1) : Math.round(inPerSecond),
+            outPerSecond < 10 ? outPerSecond.toFixed(1) : Math.round(outPerSecond),
+        )
+
+        this.inCount = 0
+        this.outCount = 0
+    }
+}

--- a/test/unit/Publisher.test.js
+++ b/test/unit/Publisher.test.js
@@ -1,0 +1,96 @@
+const assert = require('assert')
+const events = require('events')
+const sinon = require('sinon')
+const BufferMaker = require('buffermaker')
+
+const Publisher = require('../../src/Publisher')
+const StreamrBinaryMessage = require('../../src/protocol/StreamrBinaryMessage')
+const InvalidMessageContentError = require('../../src/errors/InvalidMessageContentError')
+const NotReadyError = require('../../src/errors/NotReadyError')
+
+describe('Publisher', () => {
+
+    const stream = {
+        id: 'streamId',
+        partitions: 10,
+    }
+
+    const msg = new BufferMaker().string('{}').make()
+
+    let publisher
+    let kafkaMock
+    let partitionerMock
+
+    beforeEach(() => {
+        kafkaMock = new events.EventEmitter()
+        kafkaMock.send = sinon.stub().resolves()
+        partitionerMock = {
+            partition: sinon.stub().returns(9),
+        }
+
+        publisher = new Publisher(kafkaMock, partitionerMock)
+    })
+
+    describe('publish', () => {
+        it('should return a promise', () => {
+            const promise = publisher.publish(stream, Date.now(), 0, StreamrBinaryMessage.CONTENT_TYPE_JSON, msg).catch(() => {})
+            assert(promise instanceof Promise)
+        })
+
+        it('should throw FailedToPublishError if trying to publish before Kafka is ready', (done) => {
+            publisher.publish(stream, Date.now(), 0, StreamrBinaryMessage.CONTENT_TYPE_JSON, msg).catch((err) => {
+                assert(err instanceof NotReadyError, err)
+                done()
+            })
+        })
+
+        describe('when kafka ready', () => {
+            beforeEach(() => {
+                kafkaMock.emit('ready')
+            })
+
+            it('should throw InvalidMessageContentError if no content is given', (done) => {
+                publisher.publish(stream, Date.now(), 0, StreamrBinaryMessage.CONTENT_TYPE_JSON, undefined).catch((err) => {
+                    assert(err instanceof InvalidMessageContentError)
+                    done()
+                })
+            })
+
+            it('should call the partitioner with a partition key if given', () => {
+                publisher.publish(stream, Date.now(), 0, StreamrBinaryMessage.CONTENT_TYPE_JSON, msg, 'key')
+                assert(partitionerMock.partition.calledWith(stream.partitions, 'key'))
+            })
+
+            it('should call the partitioner with undefined partition key if not given', () => {
+                publisher.publish(stream, Date.now(), 0, StreamrBinaryMessage.CONTENT_TYPE_JSON, msg)
+                assert(partitionerMock.partition.calledWith(stream.partitions, undefined))
+            })
+
+            it('should call KafkaUtil.send with a StreamrBinaryMessage with correct values', (done) => {
+                const timestamp = Date.now()
+                const ttl = 1000
+
+                kafkaMock.send = (streamrBinaryMessage) => {
+                    assert(streamrBinaryMessage instanceof StreamrBinaryMessage)
+                    assert.equal(streamrBinaryMessage.streamId, stream.id)
+                    assert.equal(streamrBinaryMessage.streamPartition, partitionerMock.partition())
+                    assert.equal(streamrBinaryMessage.timestamp, timestamp)
+                    assert.equal(streamrBinaryMessage.ttl, ttl)
+                    assert.equal(streamrBinaryMessage.contentType, StreamrBinaryMessage.CONTENT_TYPE_JSON)
+                    assert.equal(streamrBinaryMessage.content, msg)
+                    done()
+                }
+                publisher.publish(stream, timestamp, ttl, StreamrBinaryMessage.CONTENT_TYPE_JSON, msg)
+            })
+
+            it('should use default values for timestamp and ttl if not given', (done) => {
+                kafkaMock.send = (streamrBinaryMessage) => {
+                    assert(streamrBinaryMessage.timestamp > 0)
+                    assert(streamrBinaryMessage.ttl === 0)
+                    done()
+                }
+                publisher.publish(stream, undefined, undefined, StreamrBinaryMessage.CONTENT_TYPE_JSON, msg, 'key')
+            })
+        })
+    })
+})

--- a/test/unit/WebsocketServer.test.js
+++ b/test/unit/WebsocketServer.test.js
@@ -46,6 +46,8 @@ describe('WebsocketServer', () => {
                 return new Promise(((resolve, reject) => {
                     if (authKey === 'correct') {
                         resolve(myStream)
+                    } else if (authKey === 'correctButNoPermission') {
+                        reject(new Error(401))
                     } else {
                         reject(new Error(403))
                     }
@@ -736,6 +738,28 @@ describe('WebsocketServer', () => {
                     stream: 'streamId',
                     authKey: 'correct',
                     msg: {},
+                }
+
+                mockSocket.receive(req)
+            })
+
+            it('responds with an error if the api key is wrong', () => {
+                const req = {
+                    type: 'publish',
+                    stream: 'streamId',
+                    authKey: 'wrong',
+                    msg: '{}',
+                }
+
+                mockSocket.receive(req)
+            })
+
+            it('responds with an error if the user does not have permission', () => {
+                const req = {
+                    type: 'publish',
+                    stream: 'streamId',
+                    authKey: 'correctButNoPermission',
+                    msg: '{}',
                 }
 
                 mockSocket.receive(req)

--- a/test/unit/WebsocketServer.test.js
+++ b/test/unit/WebsocketServer.test.js
@@ -102,7 +102,7 @@ describe('WebsocketServer', () => {
         })
 
         it('increments connection counter', () => {
-            assert.equal(server.connectionCounter, 2)
+            assert.equal(server.volumeLogger.connectionCount, 2)
         })
     })
 
@@ -802,7 +802,7 @@ describe('WebsocketServer', () => {
         })
 
         it('decrements connection counter', () => {
-            assert.equal(server.connectionCounter, 0)
+            assert.equal(server.volumeLogger.connectionCount, 0)
         })
     })
 

--- a/test/unit/protocol/StreamrBinaryMessage.test.js
+++ b/test/unit/protocol/StreamrBinaryMessage.test.js
@@ -64,12 +64,30 @@ describe('StreamrBinaryMessage', () => {
                     assert.equal(JSON.parse.callCount, 0)
                 })
             })
+        })
 
-            it('must fail if content is not a buffer', () => {
+        describe('constructor', () => {
+            it('must accept a buffer content', () => {
+                new StreamrBinaryMessage(
+                    streamId, streamPartition, timestamp, ttl,
+                    StreamrBinaryMessage.CONTENT_TYPE_JSON, Buffer.from(JSON.stringify(msg), 'utf8'),
+                )
+            })
+
+            it('must accept a string content', () => {
+                new StreamrBinaryMessage(
+                    streamId, streamPartition, timestamp, ttl,
+                    StreamrBinaryMessage.CONTENT_TYPE_JSON, 'I AM A STRING',
+                )
+            })
+
+            it('must throw if content is not a buffer or a string', () => {
                 assert.throws(() => {
-                    /* new */ StreamrBinaryMessage(
+                    new StreamrBinaryMessage(
                         streamId, streamPartition, timestamp, ttl,
-                        StreamrBinaryMessage.CONTENT_TYPE_JSON, 'I AM NOT A BUFFER',
+                        StreamrBinaryMessage.CONTENT_TYPE_JSON, {
+                            iam: 'an object',
+                        },
                     )
                 })
             })

--- a/test/unit/rest/DataProduceEndpoints.test.js
+++ b/test/unit/rest/DataProduceEndpoints.test.js
@@ -141,14 +141,6 @@ describe('DataProduceEndpoints', () => {
         }).expect(400, done)
     })
 
-    it('should return 400 for invalid ttl', (done) => {
-        postRequest({
-            query: {
-                ttl: 'foo',
-            },
-        }).expect(400, done)
-    })
-
     it('should return 400 for invalid timestamp', (done) => {
         postRequest({
             query: {

--- a/test/unit/test-helpers/MockSocket.js
+++ b/test/unit/test-helpers/MockSocket.js
@@ -1,10 +1,12 @@
 const events = require('events')
+const encoder = require('../../../src/MessageEncoder')
 
 module.exports = class MockSocket extends events.EventEmitter {
     constructor() {
         super()
         this.rooms = []
         this.sentMessages = []
+        this.throwOnError = true
     }
 
     join(channel, cb) {
@@ -19,6 +21,14 @@ module.exports = class MockSocket extends events.EventEmitter {
 
     send(message) {
         this.sentMessages.push(message)
+
+        // Inspect the message to catch errors
+        const parsedMessage = JSON.parse(message)
+
+        // If you expect error messages, set mockSocket.throwOnError to false for those tests
+        if (parsedMessage[1] === encoder.BROWSER_MSG_TYPE_ERROR && this.throwOnError) {
+            throw new Error(`Received unexpected error message: ${parsedMessage[3]}`)
+        }
     }
 
     disconnect() {


### PR DESCRIPTION
- Allow clients to publish messages over websocket using a new `publish` message type
- Add `Publisher` abstraction to make publishing over websocket and rest endpoints more DRY
- Correctly count and log both incoming and outgoing message counts
- Remove per-message `ttl` field (`ttl` should be set on stream level)
- Bring back the ability to provide a message timestamp (feature request from OSIsoft)
