### PR TITLE
Respond 400 to websocket reqs with invalid headers

### DIFF
--- a/data-api.js
+++ b/data-api.js
@@ -14,57 +14,101 @@ const Partitioner = require('./src/Partitioner')
 const Publisher = require('./src/Publisher')
 const VolumeLogger = require('./src/utils/VolumeLogger')
 
-// Check command line args
-optimist = optimist.usage(`You must pass the following command line options:
-    --data-topic <topic> 
-    --zookeeper <conn_string> 
-    --redis <redis_hosts_separated_by_commas> 
-    --redis-pwd <password> 
-    --cassandra <cassandra_hosts_separated_by_commas> 
-    --keyspace <cassandra_keyspace> 
-    --streamr <streamr> 
-    --port <port>`)
-optimist = optimist.demand(['data-topic', 'zookeeper', 'redis', 'redis-pwd', 'cassandra', 'keyspace', 'streamr', 'port'])
+module.exports = (externalConfig) => {
+    let config
 
-// Create some utils
-const streamFetcher = new StreamFetcher(optimist.argv.streamr)
-const redis = new RedisUtil(optimist.argv.redis.split(','), optimist.argv['redis-pwd'])
-const cassandra = new CassandraUtil(optimist.argv.cassandra.split(','), optimist.argv.keyspace)
-const redisOffsetFetcher = new RedisOffsetFetcher(optimist.argv.redis.split(',')[0], optimist.argv['redis-pwd'])
-const kafka = new StreamrKafkaProducer(optimist.argv['data-topic'], Partitioner, optimist.argv.zookeeper)
-const publisher = new Publisher(kafka, Partitioner)
-const volumeLogger = new VolumeLogger()
+    if (!externalConfig) {
+        // Check command line args
+        optimist = optimist.usage(`You must pass the following command line options:
+        --data-topic <topic>
+        --zookeeper <conn_string>
+        --redis <redis_hosts_separated_by_commas>
+        --redis-pwd <password>
+        --cassandra <cassandra_hosts_separated_by_commas>
+        --keyspace <cassandra_keyspace>
+        --streamr <streamr>
+        --port <port>`)
+        optimist = optimist.demand(['data-topic', 'zookeeper', 'redis', 'redis-pwd', 'cassandra', 'keyspace', 'streamr', 'port'])
+        config = optimist.argv
+    } else {
+        config = externalConfig
+    }
 
-// Create HTTP server
-const app = express()
-const httpServer = http.Server(app)
+    // Create some utils
+    const streamFetcher = new StreamFetcher(config.streamr)
+    const redis = new RedisUtil(config.redis.split(','), config['redis-pwd'])
+    const cassandra = new CassandraUtil(config.cassandra.split(','), config.keyspace)
+    const redisOffsetFetcher = new RedisOffsetFetcher(config.redis.split(',')[0], config['redis-pwd'])
+    const kafka = new StreamrKafkaProducer(config['data-topic'], Partitioner, config.zookeeper)
+    const publisher = new Publisher(kafka, Partitioner)
+    const volumeLogger = new VolumeLogger()
 
-// Add CORS headers
-app.use(cors())
+    // Create HTTP server
+    const app = express()
+    const httpServer = http.Server(app)
 
-// Websocket endpoint is handled by WebsocketServer
-const server = new WebsocketServer(
-    new ws.Server({
-        server: httpServer,
-        path: '/api/v1/ws',
-    }),
-    redis,
-    cassandra,
-    redisOffsetFetcher,
-    streamFetcher,
-    publisher,
-    volumeLogger,
-)
+    // Add CORS headers
+    app.use(cors())
 
-// Rest endpoints
-app.use('/api/v1', require('./src/rest/DataQueryEndpoints')(cassandra, streamFetcher, volumeLogger))
-app.use('/api/v1', require('./src/rest/DataProduceEndpoints')(streamFetcher, publisher, volumeLogger))
+    // Websocket endpoint is handled by WebsocketServer
+    const server = new WebsocketServer(
+        new ws.Server({
+            server: httpServer,
+            path: '/api/v1/ws',
+            /**
+             * Gracefully reject clients sending invalid headers. Without this change, the connection gets abruptly closed,
+             * which makes load balancers such as nginx think the node is not healthy.
+             * This blocks ill-behaving clients sending invalid headers, as well as very old websocket implementations
+             * using draft 00 protocol version (https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-00)
+             */
+            verifyClient: (info, cb) => {
+                if (info.req.headers['sec-websocket-key']) {
+                    cb(true)
+                } else {
+                    cb(
+                        false,
+                        400, // bad request
+                        'Invalid headers on websocket request. Please upgrade your browser or websocket library!',
+                    )
+                }
+            },
+        }),
+        redis,
+        cassandra,
+        redisOffsetFetcher,
+        streamFetcher,
+        publisher,
+        volumeLogger,
+    )
 
-// Start the server
-httpServer.listen(optimist.argv.port, () => {
-    console.log(`Configured with Redis: ${optimist.argv.redis}`)
-    console.log(`Configured with Cassandra: ${optimist.argv.cassandra}`)
-    console.log(`Configured with Kafka: ${optimist.argv.zookeeper} and topic '${optimist.argv['data-topic']}'`)
-    console.log(`Configured with Streamr: ${optimist.argv.streamr}`)
-    console.log(`Listening on port ${optimist.argv.port}`)
-})
+    // Rest endpoints
+    app.use('/api/v1', require('./src/rest/DataQueryEndpoints')(cassandra, streamFetcher, volumeLogger))
+    app.use('/api/v1', require('./src/rest/DataProduceEndpoints')(streamFetcher, publisher, volumeLogger))
+
+    // Start the server
+    httpServer.listen(config.port, () => {
+        console.log(`Configured with Redis: ${config.redis}`)
+        console.log(`Configured with Cassandra: ${config.cassandra}`)
+        console.log(`Configured with Kafka: ${config.zookeeper} and topic '${config['data-topic']}'`)
+        console.log(`Configured with Streamr: ${config.streamr}`)
+        console.log(`Listening on port ${config.port}`)
+        httpServer.emit('listening')
+    })
+
+    return {
+        httpServer,
+        close: () => {
+            httpServer.close()
+            redis.quit()
+            redisOffsetFetcher.close()
+            cassandra.close()
+            kafka.close()
+            volumeLogger.stop()
+        },
+    }
+}
+
+// Start the server if we're not being required from another module
+if (require.main === module) {
+    module.exports()
+}

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "optimist": "*",
     "promise": "^7.1.1",
     "redis": "^2.6.2",
-    "uws": "^0.14.1"
+    "uws": "^0.14.5"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.2",

--- a/src/KafkaUtil.js
+++ b/src/KafkaUtil.js
@@ -62,4 +62,9 @@ module.exports = class KafkaUtil extends events.EventEmitter {
             })
         })
     }
+
+    close(cb) {
+        this.kafkaClient.close(cb)
+    }
+
 }

--- a/src/utils/VolumeLogger.js
+++ b/src/utils/VolumeLogger.js
@@ -6,7 +6,7 @@ module.exports = class VolumeLogger {
         this.outCount = 0
 
         if (this.reportingIntervalSeconds > 0) {
-            setInterval(() => {
+            this.interval = setInterval(() => {
                 this.log()
             }, this.reportingIntervalSeconds * 1000)
         }
@@ -25,5 +25,10 @@ module.exports = class VolumeLogger {
 
         this.inCount = 0
         this.outCount = 0
+    }
+
+    stop() {
+        console.log('VolumeLogger stopping.')
+        clearInterval(this.interval)
     }
 }

--- a/test/integration/data-api.test.js
+++ b/test/integration/data-api.test.js
@@ -1,0 +1,63 @@
+const assert = require('assert')
+const fetch = require('node-fetch')
+const WebSocket = require('uws')
+
+const port = 12345
+
+describe('data-api', () => {
+    jest.setTimeout(20 * 1000)
+
+    let dataApi
+
+    beforeAll((done) => {
+        // Start the app
+        dataApi = require('../../data-api')({
+            'data-topic': 'data-dev',
+            zookeeper: 'localhost',
+            redis: 'localhost',
+            'redis-pwd': 'not-set',
+            cassandra: 'localhost',
+            keyspace: 'streamr_dev',
+            streamr: 'http://localhost:8081/streamr-core',
+            port,
+        })
+
+        if (!dataApi.httpServer.listening) {
+            dataApi.httpServer.once('listening', done)
+        } else {
+            done()
+        }
+    })
+
+    afterAll(() => {
+        dataApi.close()
+    })
+
+    it('is listening for http requests', () => {
+        assert(dataApi.httpServer.listening)
+    })
+
+    it('accepts websocket connections', (done) => {
+        const ws = new WebSocket(`ws://localhost:${port}/api/v1/ws`)
+        ws.on('open', () => {
+            ws.close()
+            done()
+        })
+    })
+
+    it('returns 400 response code for invalid websocket requests', (done) => {
+        fetch(`http://localhost:${port}/api/v1/ws`, {
+            method: 'GET',
+            headers: {
+                Connection: 'upgrade',
+                Upgrade: 'websocket',
+                // Missing Sec-Websocket-Key header
+            },
+        }).then((res) => {
+            assert.equal(res.status, 400)
+            done()
+        }).catch((err) => {
+            done(err)
+        })
+    })
+})


### PR DESCRIPTION
This update fixes a problem with certain type of invalid websocket requests coming in (ones missing the `Sec-Websocket-Key` header). Currently, this kind of requests get closed with an empty response, causing side-effects such as making the load balancer think that the node is unhealthy.

This kind of requests are not uncommon from old clients: [the first websocket protocol draft](https://tools.ietf.org/html/draft-ietf-hybi-thewebsocketprotocol-00) used different headers, which are no longer supported in most websocket server libraries.

This update responds with the 400 (Invalid Request) status code to requests missing this header.