### PR TITLE
StreamFetcher: log errors when failing to contact E&E

### DIFF
--- a/src/StreamFetcher.js
+++ b/src/StreamFetcher.js
@@ -37,6 +37,7 @@ module.exports = class StreamFetcher {
             headers,
         }).catch((e) => {
             console.error(`failed to communicate with E&E: ${e}`)
+            throw e
         }).then((response) => {
             if (response.status !== 200) {
                 debug(
@@ -69,6 +70,7 @@ module.exports = class StreamFetcher {
             headers,
         }).catch((e) => {
             console.error(`failed to communicate with E&E: ${e}`)
+            throw e
         }).then((response) => {
             if (response.status !== 200) {
                 return response.text().then((errorMsg) => {

--- a/src/StreamFetcher.js
+++ b/src/StreamFetcher.js
@@ -35,6 +35,8 @@ module.exports = class StreamFetcher {
 
         return fetch(`${this.streamResourceUrl}/${streamId}`, {
             headers,
+        }).catch((e) => {
+            console.error(`failed to communicate with E&E: ${e}`)
         }).then((response) => {
             if (response.status !== 200) {
                 debug(
@@ -65,6 +67,8 @@ module.exports = class StreamFetcher {
 
         return fetch(`${this.streamResourceUrl}/${streamId}/permissions/me`, {
             headers,
+        }).catch((e) => {
+            console.error(`failed to communicate with E&E: ${e}`)
         }).then((response) => {
             if (response.status !== 200) {
                 return response.text().then((errorMsg) => {


### PR DESCRIPTION
A very typical reason for Data API to not work properly in an environment is its failure to communicate with E&E (e.g. given E&E url wrong or E&E not running)

Added logging to console when E&E communication fails so its easier to diagnose the problem.